### PR TITLE
fix: restored prior CSP behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ version increments reflecting both user-visible and operational impact.
 - Bumped project version to `v1.27.0`.
 - Moved Content Security Policy selection into SvelteKit `kit.csp`, keyed from `PUBLIC_ENV_MODE`/Vite mode so SvelteKit can manage CSP hashes and nonces.
 - Kept `src/hooks.server.js` focused on request-time security headers, production `Report-To` metadata, Probely diagnostics, and audit-hostname mismatch warnings.
+- Restored CSP selection diagnostics after moving CSP construction to SvelteKit configuration.
 - Updated audit CSP behavior to remain enforced without analytics or external CSP reporting allowances.
 - Updated generator metadata in `src/app.html` to reflect **SvelteKit 2.58.0**.
 - Updated local Node version files from `24.14.1` to `24.15.0`.
@@ -50,6 +51,9 @@ version increments reflecting both user-visible and operational impact.
 ### Fixed
 
 - Corrected the Playwright mobile Chrome device-profile comment to match the current `Pixel 7` profile.
+- Restored dev/test `Content-Security-Policy-Report-Only` behavior by preserving development mode fallback and local CSP reporting.
+- Corrected audit hostname diagnostics to avoid implying that hostname detection overrides `PUBLIC_ENV_MODE`.
+- Limited Probely scanner diagnostics to audit mode and removed the misleading bypass log label.
 - Added `Prerendered` to the cspell dictionary for the new SvelteKit CSP comments.
 
 ### Security

--- a/src/hooks.server.js
+++ b/src/hooks.server.js
@@ -17,14 +17,8 @@ const cspReportUri = 'https://csp.netwk.pro/.netlify/functions/csp-report';
  * @type {import('@sveltejs/kit').Handle}
  */
 export async function handle({ event, resolve }) {
-  /**
-   * 🔍 Probely scanner allowlisting
-   * - Robust UA check (case‑insensitive)
-   * - Normalized X‑Forwarded‑For parsing
-   * - Avoids false positives
-   * @see https://help.probely.com/en/articles/5112461/
-   */
-
+  // Probely scanner detection is diagnostic only. Audit mode may use this log
+  // to confirm scanner traffic without changing the request handling path.
   /** @type {string} */
   const userAgent = event.request.headers.get('user-agent') || '';
 
@@ -34,16 +28,16 @@ export async function handle({ event, resolve }) {
 
   const isProbely = isProbelyScanner({ ua: userAgent, ip: remoteIp });
 
-  if (isProbely) {
-    console.info('[Probely Bypass] Matched scanner request:', {
+  const response = await resolve(event);
+  const env = detectEnvironment(event.url.hostname);
+  const { isAudit, isProd, isTest, mode } = env;
+
+  if (isAudit && isProbely) {
+    console.info('[Audit Mode] Probely scanner detected:', {
       ip: remoteIp,
       ua: userAgent,
     });
   }
-
-  const response = await resolve(event);
-  const env = detectEnvironment(event.url.hostname);
-  const { isAudit, isProd, isTest, mode } = env;
 
   if (event.url.hostname.endsWith('audit.netwk.pro') && mode !== 'audit') {
     console.warn(

--- a/src/lib/utils/env.js
+++ b/src/lib/utils/env.js
@@ -77,7 +77,9 @@ export function detectEnvironment(hostOverride) {
     console.log('🧭 [env] Hostname:', host || '(none)');
     console.log('🧭 [env] Raw env:', import.meta.env);
     if (hostIsAudit && mode !== 'audit') {
-      console.log('[env] Host suggests audit, overriding mode.');
+      console.log(
+        '[env] Audit hostname detected; PUBLIC_ENV_MODE is still the build-time source of truth.',
+      );
     }
   }
 

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -20,12 +20,16 @@ function getCliMode() {
 }
 
 // PUBLIC_ENV_MODE is the deployment contract; other sources are only fallbacks
-// for local commands and compatibility with existing scripts.
+// for local commands and compatibility with existing scripts. Plain `vite dev`
+// does not pass `--mode`, so NODE_ENV preserves report-only CSP for dev.
+const fallbackMode =
+  process.env.NODE_ENV === 'development' ? 'development' : 'production';
+
 const envMode = (
   process.env.PUBLIC_ENV_MODE ||
   process.env.MODE ||
   getCliMode() ||
-  'production'
+  fallbackMode
 ).toLowerCase();
 
 const isAudit = envMode === 'audit';
@@ -74,7 +78,8 @@ const auditCspDirectives = {
 };
 
 // Dev and test use report-only CSP so local tooling, HMR, and diagnostics can
-// surface violations without blocking the developer workflow.
+// surface violations without blocking the developer workflow. SvelteKit requires
+// report-only policies to include a reporting directive.
 const debugCspDirectives = {
   ...sharedCspDirectives,
   'script-src': [
@@ -93,6 +98,7 @@ const debugCspDirectives = {
     'https://us.i.posthog.com',
     'https://us-assets.i.posthog.com',
   ],
+  'report-uri': ['/api/mock-csp'],
 };
 
 // SvelteKit augments these policies with hashes/nonces for framework-generated
@@ -103,6 +109,16 @@ const csp = {
     ? { reportOnly: debugCspDirectives }
     : { directives: isAudit ? auditCspDirectives : productionCspDirectives }),
 };
+
+if (isDebug || isAudit) {
+  console.info(
+    `[CSP] SvelteKit configured ${
+      isDebug
+        ? 'Content-Security-Policy-Report-Only'
+        : 'Content-Security-Policy'
+    } for ${envMode} mode.`,
+  );
+}
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

- Restored CSP selection diagnostics after moving CSP construction to SvelteKit configuration.
- Restored dev/test `Content-Security-Policy-Report-Only` behavior by preserving development mode fallback and local CSP reporting.
- Corrected audit hostname diagnostics to avoid implying that hostname detection overrides `PUBLIC_ENV_MODE`.
- Limited Probely scanner diagnostics to audit mode and removed the misleading bypass log label.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read and followed the guidelines in the **[CONTRIBUTING](https://github.com/netwk-pro/.github/blob/master/.github/CONTRIBUTING.md)** document.  
- [x] I've checked for existing Pull Requests for the same update/change.  
- [x] My code follows the project’s coding style.  
- [x] My code has been linted locally before submission.  
- [x] All new and existing tests pass.

&nbsp;

- [ ] I have updated the documentation accordingly.  
- [ ] I have added tests to cover my changes, if applicable. *(Optional, especially for new contributors)*

Pull requests are part of a collaborative process — we welcome contributions and review each one carefully. For all but the smallest changes, you can expect maintainers to request improvements or clarifications.

Please check back after opening your PR and be responsive to feedback so we can get your contribution merged quickly.

Thanks for helping improve Network Pro Strategies!
